### PR TITLE
chore: Systemd is used instead of Docker Compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,11 @@ jobs:
           ssh $SSH_USER@$SSH_HOST "
           cd ${{ secrets.LOCATION }} &&
           cd backend &&
-          docker compose stop &&
+          systemctl stop ${{ secrets.SERVICE }}
           git pull origin main &&
-          docker compose up -d &&
+          systemctl start ${{ secrets.SERVICE }} &&
           systemctl restart nginx"
+
 
         env:
           SSH_USER: ${{ secrets.SSH_USER }}


### PR DESCRIPTION
- Stop and start service using systemctl in CI workflow.
- Restart Nginx service after deployment.